### PR TITLE
[#86867928] add nucleo_unit_id filter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'cancan', '~> 1.6.7'
 gem "logical_model", '~> 0.5.8'
 gem 'activity_stream_client', '~> 0.0.14'
 gem 'overmind_client', '~> 0.0.1'
-gem 'accounts_client'
+gem 'accounts_client', '>= 0.2.8'
 gem 'messaging_client'
 
 gem 'gibbon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    accounts_client (0.2.5)
+    accounts_client (0.2.8)
       gravtastic
-      logical_model (~> 0.5.8)
+      logical_model (>= 0.5.8)
       railties (>= 3.1)
     actionmailer (3.1.0)
       actionpack (= 3.1.0)
@@ -376,7 +376,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  accounts_client
+  accounts_client (>= 0.2.8)
   activity_stream_client (~> 0.0.14)
   appsignal (>= 0.9.4)
   appsignal-mongo

--- a/lib/contact_searcher.rb
+++ b/lib/contact_searcher.rb
@@ -23,6 +23,7 @@ class ContactSearcher
   #
   # @param selector   [ Hash ]      query
   #
+  # @option selector :nucleo_unit_id, scopes to accounts with given nucleo_id
   # @option selector :telephone, searches within all telephones
   # @option selector :email, searches within all emails
   # @option selector :address
@@ -43,6 +44,16 @@ class ContactSearcher
         k = k.to_s
 
         case k
+          when 'nucleo_unit_id'
+            account = PadmaAccount.find_by_nucleo_id(v)
+            if account
+              local_account = get_account(account.name)
+              andit({
+                account_ids: local_account.id
+              })
+            else
+              raise Exceptions::ForceEmptyQuery
+            end
           when 'telephone', 'email', 'address', 'custom_attribute'
             andit({
               :contact_attributes => { '$elemMatch' => { "_type" => k.camelize, "value" => Regexp.new(v.to_s,Regexp::IGNORECASE)}}
@@ -113,6 +124,8 @@ class ContactSearcher
     clean_selector
 
     self.initial_scope.where(self.new_selector)
+  rescue Exceptions::ForceEmptyQuery
+    Contact.where(id: 'force-empty-query') # force an empty result
   end
 
   private
@@ -134,7 +147,7 @@ class ContactSearcher
   # or read it from cache of sucesive calls
   # @param account_name [String]
   def get_account(account_name)
-    sanitized_account_name = account_name.gsub('.', '_')
+    sanitized_account_name = account_name.gsub(/\.|-/, '_')
 
     if (a = instance_variable_get("@cached_account_#{sanitized_account_name}")).blank?
       a = Account.where(name: account_name).first

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -1,0 +1,3 @@
+module Exceptions
+  class ForceEmptyQuery < StandardError; end
+end

--- a/spec/lib/contact_searcher_spec.rb
+++ b/spec/lib/contact_searcher_spec.rb
@@ -5,6 +5,29 @@ describe ContactSearcher do
   let(:searcher){ContactSearcher.new()}
 
   describe "#api_where" do
+
+    context "{ nucleo_unit_id: X }" do
+      let!(:account){Account.make(name: 'acc-name', nucleo_id: 10)}
+      let(:selector){{nucleo_unit_id: 10}}
+      context "if account with nucleo_unit_id exists" do
+        before do
+          PadmaAccount.stub(:find_by_nucleo_id).and_return(PadmaAccount.new(name: 'acc-name'))
+        end
+        it "filter by account's contacts" do
+          expect(searcher.api_where(selector)).to eq Contact.where(account_ids: account.id)
+        end
+      end
+      context "if account with nucleo_unit_id does not exist" do
+        before do
+          Contact.make
+          PadmaAccount.stub(:find_by_nucleo_id).and_return(nil)
+        end
+        it "returns empty array" do
+          expect(searcher.api_where(selector).to_a).to be_empty
+        end
+      end
+    end
+
     context "if all levels are selected" do
       context "including a blank" do
         let(:selector){{level: ['',


### PR DESCRIPTION
Agrego una nueva opción de filtro a /v0/contacts 
el parámetro **nucleo_unit_id** permitirá filtrar los contactos por account pero usando el id en nucleo en lugar del account name. Es para integración más simple con la base de datos de secretaria virtual.
- Agregué al accounts_client un método .find_by_nucleo_id por si lo necesitamos en otros lugares.
